### PR TITLE
Fix login selector to target user id field

### DIFF
--- a/src/selectors.py
+++ b/src/selectors.py
@@ -1,7 +1,7 @@
 # Placeholder selectors – update to match CDAsia's live DOM.
 SEL = {
     # Login
-    "login_user": "input[name='username']",
+    "login_user": "input[name='id']",
     "login_pass": "input[name='password']",
     "login_submit": "button[type='submit']",
     "post_login_marker": "nav .user-avatar",  # an element present only after login


### PR DESCRIPTION
## Summary
- update the login user selector to target the actual id input used by CDAsia

## Testing
- ⚠️ ./scripts/launch_debug.sh --division "SEC-OGC" (fails: host is missing required Playwright system dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68dd2626a044832b8d3b7ed85bc9251d