### PR TITLE
Point login configuration to Classic portal

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 site:
-  base_url: "https://www.cdasia.com"   # adjust to exact portal
-  login_path: "/login"
+  base_url: "https://classic.cdasiaonline.com"   # adjust to exact portal
+  login_path: "/signin"
   search_path: "/search"
   downloads_subdir: "data/downloads"
   log_dir: "data/logs"


### PR DESCRIPTION
## Summary
- update the default Classic portal host and sign-in path in `config.yaml`

## Testing
- ./scripts/launch_debug.sh *(fails: missing Playwright system dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2633d490832bbe8587af75d0ab8c