### PR TITLE
Adapt scraper to Material UI opinions workflow

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,11 +1,14 @@
 site:
-  base_url: "https://classic.cdasiaonline.com"   # adjust to exact portal
+  base_url: "https://cdasiaonline.com"   # adjust to exact portal
   login_path: "/signin"
-  search_path: "/search"
+  search_path: "/"
   downloads_subdir: "data/downloads"
   log_dir: "data/logs"
 
 filters:
+  library: "Securities and Exchange"
+  sections:
+    - "Opinions"
   division: "SEC-OGC"
   keywords: ["SEC-OGC Opinion", "Office of the General Counsel"]
   year_from: 2010

--- a/src/cdasia.py
+++ b/src/cdasia.py
@@ -62,63 +62,128 @@ class CDAsiaClient:
         url = self.cfg["site"]["base_url"] + self.cfg["site"]["search_path"]
         await self.goto(url)
 
+        throttle = self.cfg["scrape"]["throttle_ms"] / 1000
+
+        library = self.cfg["filters"].get("library")
+        if library:
+            await self.page.wait_for_selector(SEL["search_library_button"], timeout=60000)
+            await self.page.click(SEL["search_library_button"])
+            await self.page.wait_for_selector(SEL["search_library_menu"], timeout=15000)
+            option_selector = SEL["search_library_option"].format(library=library)
+            await self.page.click(option_selector)
+            await asyncio.sleep(throttle)
+            try:
+                await self.page.wait_for_selector(SEL["search_backdrop"], timeout=2000)
+                await self.page.click(SEL["search_backdrop"])
+            except PlaywrightTimeout:
+                await self.page.keyboard.press("Escape")
+            finally:
+                try:
+                    await self.page.wait_for_selector(SEL["search_library_menu"], state="hidden", timeout=15000)
+                except PlaywrightTimeout:
+                    logger.warning("Library menu did not close after selection.")
+
+        sections = self.cfg["filters"].get("sections", [])
+        for section in sections:
+            section_selector = SEL["search_section_chip"].format(section=section)
+            locator = self.page.locator(section_selector)
+            if await locator.count():
+                await locator.first.click()
+                await asyncio.sleep(throttle)
+            else:
+                logger.warning(f"Section chip '{section}' not found")
+
         division = self.cfg["filters"].get("division")
         if division:
-            await self.page.fill(SEL["search_division"], division)
-            await asyncio.sleep(0.3)
+            division_selector = SEL["search_division_chip"].format(division=division)
+            locator = self.page.locator(division_selector)
+            if await locator.count():
+                await locator.first.click()
+                await asyncio.sleep(throttle)
+            else:
+                logger.warning(f"Division chip '{division}' not found")
 
-        keywords = self.cfg["filters"].get("keywords") or []
-        if keywords:
-            await self.page.fill(SEL["search_keywords"], " ".join(keywords))
-            await asyncio.sleep(0.3)
-
-        yfrom = str(self.cfg["filters"].get("year_from", ""))
-        yto = str(self.cfg["filters"].get("year_to", ""))
-        if yfrom:
-            await self.page.fill(SEL["search_year_from"], yfrom)
-        if yto:
-            await self.page.fill(SEL["search_year_to"], yto)
-
-        await asyncio.sleep(0.3)
         await self.page.click(SEL["search_submit"])
         await self.page.wait_for_selector(SEL["results_container"], timeout=60000)
+        await self.page.wait_for_selector(SEL["result_row"], timeout=60000)
 
         results = []
         max_docs = int(self.cfg["filters"].get("max_docs", 0))
 
+        async def capture_detail_url(click_target):
+            try:
+                async with self.context.expect_page(timeout=self.cfg["scrape"]["navigation_timeout_ms"]) as popup_info:
+                    await click_target.click()
+                popup = await popup_info.value
+            except PlaywrightTimeout:
+                logger.warning("Timed out waiting for detail tab to open")
+                return None
+            else:
+                try:
+                    await popup.wait_for_load_state("domcontentloaded", timeout=self.cfg["scrape"]["navigation_timeout_ms"])
+                except PlaywrightTimeout:
+                    logger.warning("Detail tab opened but did not finish loading in time")
+                href = popup.url
+                await popup.close()
+                await asyncio.sleep(throttle)
+                await self.page.bring_to_front()
+                return href
+
         while True:
-            cards = await self.page.query_selector_all(SEL["result_card"])
-            for card in cards:
-                title_el = await card.query_selector(SEL["card_title"])
-                link_el = await card.query_selector(SEL["card_link"])
-                date_el = await card.query_selector(SEL["card_date"])
-                if not (title_el and link_el):
+            rows = await self.page.query_selector_all(SEL["result_row"])
+            for row in rows:
+                ref_el = await row.query_selector(SEL["result_ref"])
+                title_el = await row.query_selector(SEL["result_title"])
+                date_el = await row.query_selector(SEL["result_date"])
+                if not (ref_el and title_el):
                     continue
-                title = (await title_el.inner_text()).strip()
-                href = await link_el.get_attribute("href")
+
+                ref_text = (await ref_el.inner_text()).strip()
+                title_text = (await title_el.inner_text()).strip()
                 date_text = (await date_el.inner_text()).strip() if date_el else ""
-                # Adjust date format as needed
+
+                link_el = await title_el.query_selector("a")
+                href = None
+                if link_el:
+                    href = await link_el.get_attribute("href")
+                if not href:
+                    href = await title_el.get_attribute("data-href")
+                if not href:
+                    href = await row.get_attribute("data-href")
+
+                if not href:
+                    href = await capture_detail_url(title_el)
+                if not href:
+                    href = await capture_detail_url(row)
+                if not href:
+                    logger.warning(f"Skipping '{title_text}' because no detail URL could be captured.")
+                    continue
+
                 date_parsed = None
-                for fmt in ["%d %B %Y", "%B %d, %Y", "%Y-%m-%d"]:
+                for fmt in ["%B %d, %Y", "%d %B %Y", "%Y-%m-%d"]:
                     try:
                         date_parsed = datetime.strptime(date_text, fmt).date()
                         break
                     except Exception:
                         continue
+
                 results.append({
-                    "title": title,
+                    "reference": ref_text,
+                    "title": title_text,
                     "href": href,
                     "date": date_text,
-                    "date_parsed": date_parsed
+                    "date_parsed": date_parsed,
                 })
+
                 if max_docs and len(results) >= max_docs:
+                    logger.info(f"Reached max_docs={max_docs}; stopping pagination.")
                     return results
 
-            next_btn = await self.page.query_selector(SEL["pagination_next"])
-            if next_btn and (await next_btn.is_enabled()):
-                await next_btn.click()
-                await self.page.wait_for_selector(SEL["results_container"], timeout=60000)
-                await asyncio.sleep(self.cfg["scrape"]["throttle_ms"]/1000)
+            next_btn = self.page.locator(SEL["pagination_next"])
+            if await next_btn.count() and await next_btn.first.is_enabled():
+                await next_btn.first.click()
+                await asyncio.sleep(throttle)
+                await self.page.wait_for_selector(SEL["result_row"], timeout=60000)
             else:
                 break
 

--- a/src/selectors.py
+++ b/src/selectors.py
@@ -1,4 +1,4 @@
-# Placeholder selectors – update to match CDAsia's live DOM.
+# Selector map aligned with the Material-UI based CDAsia portal.
 SEL = {
     # Login
     "login_user": "input[name='id']",
@@ -6,22 +6,25 @@ SEL = {
     "login_submit": "button[type='submit']",
     "post_login_marker": "nav .user-avatar",  # an element present only after login
 
-    # Search form
-    "search_division": "input[name='division']",
-    "search_keywords": "input[name='q']",
-    "search_year_from": "input[name='year_from']",
-    "search_year_to": "input[name='year_to']",
-    "search_submit": "button:has-text('Search')",
+    # Search form controls
+    "search_library_button": "#library-menu-button",
+    "search_library_menu": "#search-library-menu",
+    "search_library_option": "label.MuiMenuItem-root:has-text('{library}')",
+    "search_backdrop": "div.MuiBackdrop-root",
+    "search_section_chip": "button.MuiButtonBase-root:has-text('{section}')",
+    "search_division_chip": "button.MuiButtonBase-root:has-text('{division}')",
+    "search_submit": "#submit_btn",
 
-    # Results
-    "results_container": "#results",
-    "result_card": ".result-card",
-    "card_title": ".result-title",
-    "card_link": ".result-title a",
-    "card_date": ".result-date",
+    # Results table
+    "results_container": "table.MuiTable-root tbody",
+    "result_row": "table.MuiTable-root tbody tr",
+    "result_ref": "td:nth-of-type(1)",
+    "result_title": "td:nth-of-type(2)",
+    "result_date": "td:nth-of-type(3)",
 
     # Pagination
-    "pagination_next": "button[aria-label='Next']",
-    # Download link on detail page
-    "download_link": "a:has-text('Download')"
+    "pagination_next": "button[aria-label='Go to next page']",
+
+    # Download link on detail page (toolbar icon button)
+    "download_link": "button[aria-label='Download']"
 }


### PR DESCRIPTION
## Summary
- update configuration and selectors to match the Material UI opinions page and toolbar controls
- drive the menu-based search workflow, parse table rows, and capture opinion detail URLs
- skip results without URLs, reuse the icon download button, and persist opinion references in the download index

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dd2a0cf870832b935c6ef72d2e6656