### PR TITLE
Fix bootstrap requirements hash invocation

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -18,13 +18,13 @@ source "$VENV_PATH/bin/activate"
 
 mkdir -p "$WHEEL_DIR"
 
-current_hash=$(python - <<'PY'
+current_hash=$(python - "$REQUIREMENTS_FILE" <<'PY'
 import hashlib, sys
 from pathlib import Path
 req = Path(sys.argv[1])
 print(hashlib.sha256(req.read_bytes()).hexdigest())
 PY
-"$REQUIREMENTS_FILE")
+)
 
 stored_hash=""
 if [ -f "$REQ_HASH_FILE" ]; then


### PR DESCRIPTION
## Summary
- ensure the requirements file path is passed to Python when computing its hash in `bootstrap.sh`
- rely on Python's argv handling so the hash is read correctly on macOS and Linux

## Testing
- ./scripts/bootstrap.sh

------
https://chatgpt.com/codex/tasks/task_e_68de32838eb8832baed396347d9fe531