### PR TITLE
Add .env example template for credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and fill in your CDAsia credentials.
+# The downloader uses python-dotenv to load these values at runtime.
+# Never commit your real credentials.
+
+CDASIA_USERNAME=your.username@agency.gov
+CDASIA_PASSWORD=your-strong-password

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ vendor/
 # Environment files
 .env
 .env.*
+!.env.example
 
 # Logs
 *.log


### PR DESCRIPTION
## Summary
- add a committed .env.example file so users can copy credentials template
- update .gitignore to allow the tracked example file while still ignoring real .env files

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68de3437ad6c832ba90c0327218e3b72