### PR TITLE
Support multiple sources for CDAsia credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Copy this file to .env and fill in your CDAsia credentials.
 # The downloader uses python-dotenv to load these values at runtime.
-# Never commit your real credentials.
+# Never commit your real credentials. Alternatively, provide credentials via
+# config.yaml (auth.username/auth.password) or CLI arguments (`--username` and
+# `--prompt-password`).
 
 CDASIA_USERNAME=your.username@agency.gov
 CDASIA_PASSWORD=your-strong-password

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ chmod +x scripts/*.sh
 cp .env.example .env
 ```
 
-Open `.env` in any text editor (VS Code, Notepad, nano, etc.) and add your CDAsia username and password. Do the same for `config.yaml`, setting the year range, division, and keywords you want to download.
+Open `.env` in any text editor (VS Code, Notepad, nano, etc.) and add your CDAsia username and password. Do the same for `config.yaml`, setting the year range, division, and keywords you want to download. If you prefer not to keep credentials in `.env`, you can instead fill in the optional `auth.username` / `auth.password` fields in `config.yaml`, or launch the tool with `--username` and either `--password` or `--prompt-password` to type it interactively.
 
 ### 6. Run the downloader
 

--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,11 @@ site:
   downloads_subdir: "data/downloads"
   log_dir: "data/logs"
 
+auth:
+  # Optional: leave blank to rely on environment variables or CLI overrides
+  username:
+  password:
+
 filters:
   library: "Securities and Exchange"
   sections:


### PR DESCRIPTION
## Summary
- add CLI overrides and optional config values for supplying CDAsia credentials
- update the Playwright client to honor CLI/config credentials and improve error messaging
- document the new credential options and update the environment template

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68de37a54dd0832ba4b821d9855ca591